### PR TITLE
fix: Pass reason to immediate cancel handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fixed issue where an `.onDidCancel` handler registered on an already-cancelled `Context` was being invoked without the expected cancellation reason. (#3)
 
 ## [1.1.1] - 2021-06-09
 ### Fixed

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -78,7 +78,7 @@ class ContextImpl implements Context {
   get onDidCancel() {
     if (this[kCancellationReason]) {
       const event: Event<CancellationReason> = (callback, thisArg?) => {
-        const handle = this[kHost].setTimeout(callback.bind(thisArg), 0);
+        const handle = this[kHost].setTimeout(callback.bind(thisArg), 0, this[kCancellationReason]);
         return {
           dispose: () => {
             this[kHost].clearTimeout(handle);


### PR DESCRIPTION
When an `.onDidCancel` callback was registered on a _cancelled_ callback, the cancellation reason was not being passed to the handler.